### PR TITLE
Add sub commands and options

### DIFF
--- a/cacis.service
+++ b/cacis.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=cacis.service
+
+[Service]
+ExecStart=/usr/local/bin/cacis master --main
+ExecStop=/bin/kill -SIGTERM $MAINPID
+#Restart=always
+WorkingDirectory=/home/ubuntu/go/src/github.com/keita0805carp/cacis
+Type=simple
+User=root
+TimeoutStopSec=15
+
+[Install]
+WantedBy = multi-user.target

--- a/cacis/build.go
+++ b/cacis/build.go
@@ -1,0 +1,28 @@
+package cacis
+
+import (
+  "log"
+)
+
+const (
+  registry = "localhost:32000"
+)
+
+func BuildFromDockerfile(dockerfilePath, imageTag string) {
+  tag := registry + "/" + imageTag
+  log.Println("Build with tag")
+  ExecCmd("docker build -t " + tag + " " + dockerfilePath, true)
+  log.Println("Push")
+  ExecCmd("docker push " + tag, true)
+}
+
+func PullAndPush(imageRef string) {
+  tag := registry + "/" + imageRef
+  log.Println("Docker pull")
+  ExecCmd("docker pull " + imageRef, true)
+  log.Println("Docker tag")
+  ExecCmd("docker tag " + imageRef + " " + tag, false)
+  log.Println("Push")
+  ExecCmd("docker push " + tag, true)
+}
+

--- a/cacis/env.go
+++ b/cacis/env.go
@@ -22,6 +22,7 @@ var (
     "dashboard.img"       : "docker.io/kubernetesui/dashboard:v2.0.0",
     "hostpath-arm64.img"  : "docker.io/cdkbot/hostpath-provisioner-arm64:1.0.0",
     "registry-arm64.img"  : "docker.io/cdkbot/registry-arm64:2.6",
+    "metrics-scraper.img" : "docker.io/kubernetesui/metrics-scraper:v1.0.4",
   }
   Microk8sSnaps = []string{"microk8s_2347.assert", "microk8s_2347.snap"}
   Snapd = []string{"core_11420.assert", "core_11420.snap"}

--- a/cacis/env.go
+++ b/cacis/env.go
@@ -20,6 +20,8 @@ var (
     "coredns.img"         : "docker.io/coredns/coredns:1.8.0",
     "metrics-server.img"  : "k8s.gcr.io/metrics-server-arm64:v0.3.6",
     "dashboard.img"       : "docker.io/kubernetesui/dashboard:v2.0.0",
+    "hostpath-arm64.img"  : "docker.io/cdkbot/hostpath-provisioner-arm64:1.0.0",
+    "registry-arm64.img"  : "docker.io/cdkbot/registry-arm64:2.6",
   }
   Microk8sSnaps = []string{"microk8s_2347.assert", "microk8s_2347.snap"}
   Snapd = []string{"core_11420.assert", "core_11420.snap"}

--- a/cacis/shared.go
+++ b/cacis/shared.go
@@ -31,11 +31,8 @@ func ExecCmd(command string, log bool) ([]byte, error) {
   if log {
     fmt.Println(string(stdout))
     Error(err)
-    return stdout, err
-  } else {
-    return nil, err
   }
-  //fmt.Printf("exec: %s\noutput:\n%s", cmd, stdout)
+  return stdout, err
 }
 
 func SortKeys(m map[string]string) []string {

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+  "fmt"
+
+  "github.com/keita0805carp/cacis/slave"
+
+  "github.com/spf13/cobra"
+)
+
+var (
+  cleanupCmd = &cobra.Command{
+    Use: "cleanup",
+    Short: "Uninstall and Cleanup",
+    Run: cleanupCommand,
+  }
+)
+
+func cleanupCommand(cmd *cobra.Command, args []string) {
+  if err := cleanupAction(); err != nil {
+    Exit(err, 1)
+  }
+}
+
+func cleanupAction() (err error) {
+  fmt.Println("cleanup command")
+  slave.RemoveMicrok8s()
+  return nil
+}
+
+func init() {
+  RootCmd.AddCommand(cleanupCmd)
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+  "fmt"
+
+  "github.com/keita0805carp/cacis/master"
+
+  "github.com/spf13/cobra"
+)
+
+var (
+    configCmd = &cobra.Command{
+        Use: "config",
+        Run: configCommand,
+    }
+)
+var Source string
+
+func configCommand(cmd *cobra.Command, args []string) {
+    if err := configAction(); err != nil {
+        Exit(err, 1)
+    }
+}
+
+func configAction() (err error) {
+  fmt.Println("Export Config")
+  master.ExportKubeconfig("/home/ubuntu/.kube/config")
+  return nil
+}
+
+func init() {
+    RootCmd.AddCommand(configCmd)
+    configCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,26 +9,38 @@ import (
 )
 
 var (
-    configCmd = &cobra.Command{
-        Use: "config",
-        Run: configCommand,
-    }
+  get    bool
+  path   string
+
+  configCmd = &cobra.Command{
+    Use: "config",
+    Short: "Manage kubeconfig",
+    Run: configCommand,
+  }
 )
-var Source string
 
 func configCommand(cmd *cobra.Command, args []string) {
-    if err := configAction(); err != nil {
-        Exit(err, 1)
-    }
+  if err := configAction(); err != nil {
+    Exit(err, 1)
+  }
 }
 
 func configAction() (err error) {
-  fmt.Println("Export Config")
-  master.ExportKubeconfig("/home/ubuntu/.kube/config")
+  if path != "" {
+    fmt.Println("Export Config")
+    master.ExportKubeconfig(path)
+    return nil
+  }
+  if get {
+    str, _ := master.GetKubeconfig()
+    fmt.Println(str)
+    return nil
+  }
   return nil
 }
 
 func init() {
-    RootCmd.AddCommand(configCmd)
-    configCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
+  RootCmd.AddCommand(configCmd)
+  configCmd.Flags().BoolVarP(&get, "get", "g", true, "Get kubeconfig")
+  configCmd.Flags().StringVarP(&path, "path", "f", "", "Export kubeconfig")
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+  "os/exec"
+
+	"github.com/keita0805carp/cacis/cacis"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+  token       bool
+  patch       bool
+  portfoward  bool
+
+  dashboardCmd = &cobra.Command{
+    Use: "dashboard",
+    Short: "Controll Kubrentes dashboard",
+    Run: dashboardCommand,
+  }
+)
+
+func dashboardCommand(cmd *cobra.Command, args []string) {
+  if err := dashboardAction(); err != nil {
+    Exit(err, 1)
+  }
+}
+
+func dashboardAction() (err error) {
+  fmt.Println("Dashboard command")
+  if token {
+    fmt.Println("Token")
+    output, err := exec.Command("sh", "-c", "kubectl -n kube-system describe $(kubectl -n kube-system get secret -o name | grep kubernetes-dashboard-token)").CombinedOutput()
+    cacis.Error(err)
+    fmt.Println(string(output))
+  } else if patch {
+    fmt.Println("Patch")
+    output, err := exec.Command("sh", "-c", "kubectl -n kube-system patch service kubernetes-dashboard -p '{\"spec\":{\"type\":\"NodePort\"}}'").CombinedOutput()
+    cacis.Error(err)
+    fmt.Println(string(output))
+  } else if portfoward {
+    fmt.Println("Portforwarding...")
+    output, err := exec.Command("sh", "-c", "kubectl -n kube-system port-forward --address 0.0.0.0 service/kubernetes-dashboard 8443:443").CombinedOutput()
+    cacis.Error(err)
+    fmt.Println(string(output))
+  } else {
+    fmt.Println("Error: Need some optinos")
+    Exit(err, 1)
+  }
+  return nil
+}
+
+func init() {
+  RootCmd.AddCommand(dashboardCmd)
+  dashboardCmd.Flags().BoolVarP(&patch, "patch", "p", false, "Patch svc/kubernetes-dashboard: ClusterIP => NodePort")
+  dashboardCmd.Flags().BoolVarP(&token, "token", "t", false, "Show dashboard token")
+  dashboardCmd.Flags().BoolVarP(&portfoward, "portfoward", "P", false, "Portfoward dashboard to 0.0.0.0:8443")
+}

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+  "fmt"
+
+  "github.com/keita0805carp/cacis/cacis"
+
+  "github.com/spf13/cobra"
+)
+
+var (
+  dockerfileDir string
+  imageRef       string
+
+  imageCmd = &cobra.Command{
+    Use: "image",
+    Short: "Manage image",
+    Run: imageCommand,
+  }
+)
+
+func imageCommand(cmd *cobra.Command, args []string) {
+  if err := imageAction(); err != nil {
+    Exit(err, 1)
+  }
+}
+
+func imageAction() (err error) {
+  fmt.Println("image command")
+  if dockerfileDir != "" && imageRef != "" {
+    fmt.Println("from dockerfile")
+    cacis.BuildFromDockerfile(dockerfileDir, imageRef)
+  } else if imageRef != "" {
+    fmt.Println("from imageRef")
+    cacis.PullAndPush(imageRef)
+  } else if dockerfileDir != "" && imageRef == "" {
+    fmt.Println("Error: need imageRef")
+    Exit(err, 1)
+  } else {
+    fmt.Println("Please set option")
+    Exit(err, 1)
+  }
+  return nil
+}
+
+func init() {
+  RootCmd.AddCommand(imageCmd)
+  imageCmd.Flags().StringVarP(&dockerfileDir,  "dir", "d", "", "docker build(tag)->push")
+  imageCmd.Flags().StringVarP(&imageRef, "image", "i", "", "docker pull->tag->push")
+}

--- a/cmd/master.go
+++ b/cmd/master.go
@@ -19,6 +19,7 @@ var (
 
   masterCmd = &cobra.Command{
     Use: "master",
+    Short: "Run Master Process",
     Run: masterCommand,
   }
 )

--- a/cmd/master.go
+++ b/cmd/master.go
@@ -3,9 +3,9 @@ package cmd
 import (
   "log"
   "os"
+  "syscall"
   "os/signal"
   "time"
-  "strings"
 
   "github.com/keita0805carp/cacis/master"
   "github.com/keita0805carp/cacis/connection"
@@ -14,48 +14,51 @@ import (
 )
 
 var (
-    masterCmd = &cobra.Command{
-        Use: "master",
-        Run: masterCommand,
-    }
+  main  bool
+  setup bool
+
+  masterCmd = &cobra.Command{
+    Use: "master",
+    Run: masterCommand,
+  }
 )
 
 func masterCommand(cmd *cobra.Command, args []string) {
-    if err := masterAction(); err != nil {
-        Exit(err, 1)
-    }
+  if err := masterAction(); err != nil {
+    Exit(err, 1)
+  }
 }
 
 func masterAction() (err error) {
-    log.Printf("\n[Debug]: Run Main Master Process\n")
+  log.Printf("\n[Debug]: Run Master Process\n")
 
+  if main {
+    log.Printf("\n[Debug]: Main Mode\n")
     terminate := make(chan os.Signal, 1)
-    signal.Notify(terminate, os.Interrupt)
-
-    adapterAddr, adapterId := connection.Initialize()
-    //UUID := connection.genUUID()
-    UUID := "12345678-9012-3456-7890-abcdefabcdef"
-    ssid := strings.Replace(adapterAddr, ":", "", 5)
-    pass := strings.Replace(UUID, "-", "", 4)
-
+    signal.Notify(terminate, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
     cancel := make(chan struct{})
-    go connection.Advertise(cancel, UUID, adapterAddr, adapterId, ssid, pass)
 
-    go connection.StartHostapd(cancel, ssid, pass)
-
-    go connection.DHCP(cancel)
-
-    master.Main(cancel)
+    connection.Main(cancel)
+    go master.Main(cancel)
 
     <-terminate
     close(cancel)
     log.Printf("\n[Debug]: Terminating Main Master Process...\n")
     time.Sleep(10 * time.Second)
     log.Printf("\n[Debug]: Terminate Main Master Process\n")
-
     return nil
+  } else if setup {
+    log.Printf("\n[Debug]: Setup Mode\n")
+    master.Setup()
+    return nil
+  } else {
+    log.Println("Please select option '--main' or '--setup'")
+    return nil
+  }
 }
 
 func init() {
-    RootCmd.AddCommand(masterCmd)
+  RootCmd.AddCommand(masterCmd)
+  masterCmd.Flags().BoolVarP(&main, "main", "m", false, "Main Mode")
+  masterCmd.Flags().BoolVarP(&setup, "setup", "s", false, "Setup Mode")
 }

--- a/cmd/master.go
+++ b/cmd/master.go
@@ -34,7 +34,7 @@ func masterAction() (err error) {
   log.Printf("\n[Debug]: Run Master Process\n")
 
   if main {
-    log.Printf("\n[Debug]: Main Mode\n")
+    log.Printf("[Debug]: Main Mode\n")
     terminate := make(chan os.Signal, 1)
     signal.Notify(terminate, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
     cancel := make(chan struct{})
@@ -46,7 +46,7 @@ func masterAction() (err error) {
     close(cancel)
     log.Printf("\n[Debug]: Terminating Main Master Process...\n")
     time.Sleep(10 * time.Second)
-    log.Printf("\n[Debug]: Terminate Main Master Process\n")
+    log.Printf("\n[Debug]: Terminated Main Master Process\n")
     return nil
   } else if setup {
     log.Printf("\n[Debug]: Setup Mode\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,37 +1,37 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
+  "fmt"
+  "os"
 
-    "github.com/spf13/cobra"
+  "github.com/spf13/cobra"
 )
 
 var (
-    // RootCmd defines root command
-    RootCmd = &cobra.Command{
-        Use: "cacis",
-        Run: func(cmd *cobra.Command, args []string) {
-            cmd.Usage()
-        },
-    }
+  // RootCmd defines root command
+  RootCmd = &cobra.Command{
+    Use: "cacis",
+    Run: func(cmd *cobra.Command, args []string) {
+      cmd.Usage()
+    },
+  }
 )
 
 // Run runs command.
 func Run() {
-    RootCmd.Execute()
+  RootCmd.Execute()
 }
 
 // Exit finishes a runnning action.
 func Exit(err error, codes ...int) {
-    var code int
-    if len(codes) > 0 {
-        code = codes[0]
-    } else {
-        code = 2
-    }
-    if err != nil {
-        fmt.Println(err)
-    }
-    os.Exit(code)
+  var code int
+  if len(codes) > 0 {
+    code = codes[0]
+  } else {
+    code = 2
+  }
+  if err != nil {
+    fmt.Println(err)
+  }
+  os.Exit(code)
 }

--- a/cmd/slave.go
+++ b/cmd/slave.go
@@ -10,28 +10,29 @@ import (
 )
 
 var (
-    slaveCmd = &cobra.Command{
-        Use: "slave",
-        Run: slaveCommand,
-    }
+  slaveCmd = &cobra.Command{
+    Use: "slave",
+    Short: "Run Slave Process",
+    Run: slaveCommand,
+  }
 )
 
 func slaveCommand(cmd *cobra.Command, args []string) {
-    if err := slaveAction(); err != nil {
-        Exit(err, 1)
-    }
+  if err := slaveAction(); err != nil {
+    Exit(err, 1)
+  }
 }
 
 func slaveAction() (err error) {
-    log.Printf("\n[Debug]: Run Main Slave Process\n")
+  log.Printf("\n[Debug]: Run Main Slave Process\n")
 
-    ssid, pw := connection.GetWifiInfo()
-    connection.Connect(ssid, pw)
-    slave.Main()
+  ssid, pw := connection.GetWifiInfo()
+  connection.Connect(ssid, pw)
+  slave.Main()
 
-    return nil
+  return nil
 }
 
 func init() {
-    RootCmd.AddCommand(slaveCmd)
+  RootCmd.AddCommand(slaveCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,23 +6,24 @@ import (
 )
 
 var (
-    versionCmd = &cobra.Command{
-        Use: "version",
-        Run: versionCommand,
-    }
+  versionCmd = &cobra.Command{
+    Use: "version",
+    Short: "Show version",
+    Run: versionCommand,
+  }
 )
 
 func versionCommand(cmd *cobra.Command, args []string) {
-    if err := versionAction(); err != nil {
-        Exit(err, 1)
-    }
+  if err := versionAction(); err != nil {
+    Exit(err, 1)
+  }
 }
 
 func versionAction() (err error) {
-    fmt.Println("version: 0.0.1")
-    return nil
+  fmt.Println("version: 0.0.1")
+  return nil
 }
 
 func init() {
-    RootCmd.AddCommand(versionCmd)
+  RootCmd.AddCommand(versionCmd)
 }

--- a/connection/advertise.go
+++ b/connection/advertise.go
@@ -39,7 +39,7 @@ func Advertise(cancel chan struct{}, UUID, adapterAddr, adapterId, ssid, pass st
   log.Printf("[Info]  SSID: %s\n", ssid)
   log.Printf("[Info]  PASS: %s\n", pass)
 
-  timeout := uint32(6 * 3600) // 6h
+  timeout := uint32(65536 * 3600)
   log.Printf("[Debug] Advertising...\n")
   stop, err := app.Advertise(timeout)
   cacis.Error(err)

--- a/connection/discover.go
+++ b/connection/discover.go
@@ -41,23 +41,17 @@ func discoverBLE(a *adapter.Adapter1) (*device.Device1, error) {
   for ev := range discoverd {
 
     dev, err := device.NewDevice1(ev.Path)
-    cacis.Error(err)
-
-    if dev == nil || dev.Properties == nil {
+    if err != nil || dev == nil || dev.Properties == nil {
       continue
     }
 
-    properties := dev.Properties
+    log.Printf("[Debug] Discovered (%s) %s\n", dev.Properties.Alias, dev.Properties.Address)
 
-    log.Printf("[Debug] Discovered (%s) %s\n", properties.Alias, properties.Address)
+    isCacisNode := regexp.MustCompile(`^cacis-[0-9a-fA-F]{8}$`).MatchString(dev.Properties.Alias)
 
-    isCacisNode := regexp.MustCompile(`^cacis-[0-9a-fA-F]{8}$`).MatchString(properties.Alias)
-
-    if !isCacisNode {
-      continue
+    if isCacisNode {
+      return dev, nil
     }
-
-    return dev, nil
   }
   return nil, nil
 }

--- a/connection/hostapd.conf.template
+++ b/connection/hostapd.conf.template
@@ -1,10 +1,12 @@
 interface=wlan0
 ssid={{SSID}}
 
-channel=2
+# Station MAC address -based authentication
 macaddr_acl=0
-ignore_broadcast_ssid=1 #stealth
-driver=nl80211
+# Stealth
+ignore_broadcast_ssid=1
+
+# Security
 wpa=2
 wpa_passphrase={{PASSWORD}}
 wpa_key_mgmt=WPA-PSK
@@ -13,6 +15,7 @@ rsn_pairwise=CCMP
 
 # Socket
 ctrl_interface=/var/run/hostapd
+driver=nl80211
 
 # Log
 logger_syslog_level=2
@@ -20,20 +23,20 @@ logger_syslog_level=2
 
 # Other
 country_code=JP
-
-ieee80211n=1
+wmm_enabled=1
+channel=36
+ieee80211h=1
+ieee80211d=1
+ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40][DSSS_CCK-40][MAX-AMSDU-3839]
 
 # Operation mode (a=IEEE 802.11a (5 GHz), b = IEEE 802.11b (2.4 GHz),
 # g=IEEE 802.11g (2.4 GHz), ad = IEEE 802.11ad (60 GHz);
 # Default: IEEE 802.11b
-#hw_mode=g
+hw_mode=a
 
 # Maximum number of stations allowed in station table.
 # (default: 2007)
 max_num_sta=255
-
-# Station MAC address -based authentication
-macaddr_acl=0
 
 # Accept/deny lists are read from separate files (containing list of
 # MAC addresses, one per line). Use absolute path name to make sure that the
@@ -50,6 +53,8 @@ macaddr_acl=0
 auth_algs=1
 
 ##### IEEE 802.11n related configuration #####################################
+ieee80211n=1
 ##### IEEE 802.11ac related configuration #####################################
+ieee80211ac=1
 ##### Wi-Fi Protected Setup (WPS) #############################################
 

--- a/connection/main.go
+++ b/connection/main.go
@@ -1,0 +1,23 @@
+package connection
+
+import (
+  "time"
+  "strings"
+)
+
+func Main(cancel chan struct{}) {
+  adapterAddr, adapterId := Initialize()
+  //UUID := connection.genUUID()
+  UUID := "12345678-9012-3456-7890-abcdefabcdef"
+  ssid := strings.Replace(adapterAddr, ":", "", 5)
+  pass := strings.Replace(UUID, "-", "", 4)
+
+  go StartHostapd(cancel, ssid, pass)
+
+  go Advertise(cancel, UUID, adapterAddr, adapterId, ssid, pass)
+
+  go DHCP(cancel)
+
+  time.Sleep(3*time.Second)
+  return
+}

--- a/master/k8s.go
+++ b/master/k8s.go
@@ -69,8 +69,8 @@ func installMicrok8s() {
   } else {
     log.Printf("Install microk8s via snap\n")
     log.Printf("Installing...")
-    cacis.ExecCmd("snap ack " + targetDir + "microk8s_2347.assert", false)
-    cacis.ExecCmd("snap install " + targetDir + "microk8s_2347.snap" + " --classic", true)
+    cacis.ExecCmd("snap ack " + targetDir + cacis.Microk8sSnaps[0], false)
+    cacis.ExecCmd("snap install " + targetDir + cacis.Microk8sSnaps[1] + " --classic", true)
     log.Printf("[Debug] Installed\n")
     log.Printf("[Debug] Waiting for ready\n")
     cacis.ExecCmd("microk8s status --wait-ready", false)

--- a/master/k8s.go
+++ b/master/k8s.go
@@ -79,7 +79,7 @@ func installMicrok8s() {
 }
 
 func enableMicrok8s() {
-  cacis.ExecCmd("microk8s enable dns dashboard", false)
+  cacis.ExecCmd("microk8s enable registry dns dashboard", false)
 }
 
 func GetKubeconfig() (string, error) {

--- a/master/k8s.go
+++ b/master/k8s.go
@@ -4,6 +4,7 @@ import (
   "fmt"
   "log"
   "net"
+  "os"
 
   "github.com/keita0805carp/cacis/cacis"
 )
@@ -81,7 +82,16 @@ func enableMicrok8s() {
   cacis.ExecCmd("microk8s enable dns dashboard", false)
 }
 
-func getKubeconfig() {
-  cacis.ExecCmd("microk8s config", true)
+func GetKubeconfig() (string, error) {
+  config, err := cacis.ExecCmd("microk8s config", false)
+  return string(config), err
+}
+
+func ExportKubeconfig(path string) (error) {
+  config, err := GetKubeconfig()
+  file, err := os.Create(path)
+  cacis.Error(err)
+  _, err = file.WriteString(config)
+  return err
 }
 

--- a/master/k8s.go
+++ b/master/k8s.go
@@ -79,7 +79,9 @@ func installMicrok8s() {
 }
 
 func enableMicrok8s() {
+  log.Println("enable add-on...")
   cacis.ExecCmd("microk8s enable registry dns dashboard", false)
+  log.Println("enabled add-on")
 }
 
 func GetKubeconfig() (string, error) {

--- a/master/master.go
+++ b/master/master.go
@@ -103,7 +103,7 @@ func handling(conn net.Conn) {
   }
 }
 
-func getImgList() {
+func getImgList() []string {
   log.Printf("\n[Info] Show images list")
 
   ctx, client := ContainerdInit()
@@ -111,10 +111,11 @@ func getImgList() {
 
   images, err := client.ListImages(ctx)
   cacis.Error(err)
-  for _, image := range images {
-    fmt.Println(image.Name())
+  imagesName := make([]string, len(images))
+  for i, image := range images {
+    imagesName[i] = image.Name()
   }
-  return 
+  return imagesName
 }
 
 func pullImg(imageName string) {

--- a/master/master.go
+++ b/master/master.go
@@ -47,8 +47,7 @@ func Main(cancel chan struct{}) {
       log.Printf("[Debug] Waiting slave\n\n")
       conn, err := listen.Accept()
       cacis.Error(err)
-      handling(conn)
-      conn.Close()
+      go handling(conn)
     case <- cancel:
       log.Println("[Debug] Terminating Main server...")
       cacis.ExecCmd("microk8s stop", false)
@@ -102,6 +101,7 @@ func handling(conn net.Conn) {
   } else {
     log.Println("[Error] Unknown Type")
   }
+  conn.Close()
 }
 
 func getImgList() []string {

--- a/master/master.go
+++ b/master/master.go
@@ -26,14 +26,15 @@ var (
   componentsList = cacis.ComponentsList
 )
 
-func Main(cancel chan struct{}) {
+func Setup() {
   downloadMicrok8s()
   installMicrok8s()
-  exportAndPullAllImg()
-  go server(cancel)
+  enableMicrok8s()
+  exportAndPullAllImg(false)
+  //fmt.Println(getImgList())
 }
 
-func server(cancel chan struct{}) {
+func Main(cancel chan struct{}) {
   log.Println("[Debug] Starting Main Server")
   // Socket
   listen, err := net.Listen("tcp", masterIP+":"+masterPort)
@@ -159,13 +160,17 @@ func exportImg(filePath, imageRef string){
   log.Printf("\r[Info]  Exported  %s to %s Completely\n", imageRef, filePath)
 }
 
-func exportAndPullAllImg(){
+func exportAndPullAllImg(onlyExport bool){
   log.Printf("[Debug] start: Pull and Export Images\n")
   log.Printf("\n[Debug] Pull %d images for Kubernetes Components\n", len(componentsList))
   for exportFile, imageRef := range componentsList {
     //fmt.Printf("%s : %s\n", exporttDir + exportFile, imageRef)
-    pullImg(imageRef)
-    exportImg(targetDir + exportFile, imageRef)
+    if onlyExport {
+      exportImg(targetDir + exportFile, imageRef)
+    } else {
+      pullImg(imageRef)
+      exportImg(targetDir + exportFile, imageRef)
+    }
   }
   log.Printf("\n[Debug] end: Pull and Export Images\n\n")
 }

--- a/master/master.go
+++ b/master/master.go
@@ -46,6 +46,7 @@ func Main(cancel chan struct{}) {
     default:
       log.Printf("[Debug] Waiting slave\n\n")
       conn, err := listen.Accept()
+      defer conn.Close()
       cacis.Error(err)
       go handling(conn)
     case <- cancel:
@@ -101,7 +102,6 @@ func handling(conn net.Conn) {
   } else {
     log.Println("[Error] Unknown Type")
   }
-  conn.Close()
 }
 
 func getImgList() []string {

--- a/master/master.go
+++ b/master/master.go
@@ -103,18 +103,11 @@ func handling(conn net.Conn) {
   }
 }
 
-func containerdInit() (context.Context, *containerd.Client) {
-  ctx := context.Background()
-  client, err := containerd.New(containerdSock, containerd.WithDefaultNamespace(containerdNameSpace))
-  defer client.Close()
-  cacis.Error(err)
-  return ctx, client
-}
-
 func getImgList() {
   log.Printf("\n[Info] Show images list")
 
-  ctx, client := containerdInit()
+  ctx, client := ContainerdInit()
+  defer client.Close()
 
   images, err := client.ListImages(ctx)
   cacis.Error(err)
@@ -127,7 +120,8 @@ func getImgList() {
 func pullImg(imageName string) {
   log.Printf("\n[Info]  Pulling   %s ...", imageName)
 
-  ctx, client := containerdInit()
+  ctx, client := ContainerdInit()
+  defer client.Close()
 
   opts := []containerd.RemoteOpt{
     containerd.WithAllMetadata(),
@@ -146,7 +140,8 @@ func pullImg(imageName string) {
 func exportImg(filePath, imageRef string){
   log.Printf("\r[Info]  Exporting %s to %s ...", imageRef, filePath)
 
-  ctx, client := containerdInit()
+  ctx, client := ContainerdInit()
+  defer client.Close()
 
   f, err := os.Create(filePath)
   defer f.Close()
@@ -244,5 +239,12 @@ func readFileByte(fileName string) []byte {
   file.Read(fileBuf)
 
   return fileBuf
+}
+
+func ContainerdInit() (context.Context, *containerd.Client) {
+  ctx := context.Background()
+  client, err := containerd.New(containerdSock, containerd.WithDefaultNamespace(containerdNameSpace))
+  cacis.Error(err)
+  return ctx, client
 }
 

--- a/slave/k8s.go
+++ b/slave/k8s.go
@@ -60,8 +60,8 @@ func recieveMicrok8s() {
 func installMicrok8s() {
   log.Printf("Install microk8s via snap\n")
   log.Printf("Installing...")
-  cacis.ExecCmd("snap ack " + targetDir + "microk8s_2347.assert", false)
-  cacis.ExecCmd("snap install " + targetDir + "microk8s_2347.snap" + " --classic", true)
+  cacis.ExecCmd("snap ack " + targetDir + cacis.Microk8sSnaps[0], false)
+  cacis.ExecCmd("snap install " + targetDir + cacis.Microk8sSnaps[1] + " --classic", true)
   log.Printf("[Debug] Installed\n")
 }
 

--- a/slave/k8s.go
+++ b/slave/k8s.go
@@ -71,10 +71,9 @@ func waitReadyMicrok8s() {
   log.Printf("[Debug] Microk8s is Ready\n")
 }
 
-func removeMicrok8s() {
+func RemoveMicrok8s() {
   cacis.ExecCmd("microk8s stop", false)
   cacis.ExecCmd("microk8s reset --destroy-storage", false)
   cacis.ExecCmd("snap remove --purge microk8s", false)
-  cacis.ExecCmd("apt purge snap", false)
 }
 

--- a/slave/k8s.go
+++ b/slave/k8s.go
@@ -72,8 +72,8 @@ func waitReadyMicrok8s() {
 }
 
 func RemoveMicrok8s() {
-  cacis.ExecCmd("microk8s stop", false)
-  cacis.ExecCmd("microk8s reset --destroy-storage", false)
-  cacis.ExecCmd("snap remove --purge microk8s", false)
+  cacis.ExecCmd("microk8s stop", true)
+  cacis.ExecCmd("microk8s reset --destroy-storage", true)
+  cacis.ExecCmd("snap remove --purge microk8s", true)
 }
 

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -82,7 +82,7 @@ func recieveComponentsList() map[string]string {
   log.Printf("[Debug] Read Packet PAYLOAD\n")
   cLayer.Payload = loadPayload(conn, cLayer.Length)
 
-  log.Printf("\r[Debug] Completed  %d\n", len(cLayer.Payload))
+  log.Printf("\r\n[Debug] Completed  %d\n", len(cLayer.Payload))
 
   var tmpList map[string]string
   err = json.Unmarshal(cLayer.Payload, &tmpList)
@@ -222,7 +222,7 @@ func loadPayload(conn net.Conn, targetBytes uint64) []byte {
     recievedBytes += packetLength
     packet = append(packet, buf[:packetLength]...)
     //log.Printf("\r[Debug] recieving...")
-    fmt.Printf("\r[Info]  Completed  %d  of %d\n", len(packet), int(targetBytes))
+    fmt.Printf("\r[Info]  Completed  %d  of %d", len(packet), int(targetBytes))
   }
   return packet
 }

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -6,10 +6,10 @@ import (
   "log"
   "net"
   "time"
-  "context"
   "encoding/json"
 
   "github.com/keita0805carp/cacis/cacis"
+  "github.com/keita0805carp/cacis/master"
 
   "github.com/containerd/containerd"
 )
@@ -35,7 +35,7 @@ func Main() {
 
   waitReadyMicrok8s()
   clustering()
-  fmt.Println("[TEST] wait 30 seconds...")
+  fmt.Println("[TEST] wait 60 seconds...")
   time.Sleep(60 * time.Second)
   unclustering()
   //TODO remove microk8s
@@ -115,10 +115,7 @@ func recieveImg(s []string) {
 func importImg(imageName, filePath string) {
   log.Println("[Debug] Importing " + imageName + " from " + filePath + "...")
 
-  ctx := context.Background()
-  client, err := containerd.New(containerdSock, containerd.WithDefaultNamespace(containerdNameSpace))
-  defer client.Close()
-  cacis.Error(err)
+  ctx, client := master.ContainerdInit()
 
   f, err := os.Open(filePath)
   defer f.Close()

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -96,7 +96,7 @@ func recieveImg(s []string) {
   log.Printf("[Debug] Requested\n\n")
 
   for _, fileName := range s {
-    go recieveFile(conn, fileName)
+    recieveFile(conn, fileName)
   }
   log.Printf("[Debug] end: RECIEVE COMPONENT IMAGES\n")
 }


### PR DESCRIPTION
## Change
- Add images to components-list for add-on
- Add sub command and options
  - config: export kube config
  - cleanup: uninstall microk8s and cleanup
  - dashboard: manage k8s dashboard (patch service, portfoward, export token)
  - image: build from Dockerfile or pull → push to local registry
- Add systemd unit file `cacis.service`
- Refactoring